### PR TITLE
Extend and fix util.top_and_tail

### DIFF
--- a/bruges/util/test/util_test.py
+++ b/bruges/util/test/util_test.py
@@ -14,15 +14,13 @@ from bruges.util import next_pow2, rms, top_and_tail
 class UtilTest(unittest.TestCase):
 
     def test_toptail(self):
-        mask = np.asarray([np.nan, np.nan, 3, 4, 5, np.nan])
-        a = np.asarray([1, 2, 3, 4, 5, 6])
+        a = np.asarray([np.nan, np.nan, 3, 4, 5, np.nan])
         b = np.asarray([6, 5, 4, 3, 2, 1])
         c = np.asarray([1, 2, 3, 4, 5, 6])
         d = np.asarray([6, 5, 4, 3, 2, 1])
         A, B, C, D = top_and_tail(a, b, c, d)
         for arr in (A, B, C, D):
-            for item in arr:
-                self.assertFalse(np.isnan(item))
+            self.assertEqual(len(arr), 3)
 
     def test_nextpow2(self):
         num = 888

--- a/bruges/util/test/util_test.py
+++ b/bruges/util/test/util_test.py
@@ -8,10 +8,21 @@ Testing util.
 """
 import unittest
 import numpy as np
-from bruges.util import next_pow2, rms
+from bruges.util import next_pow2, rms, top_and_tail
 
 
 class UtilTest(unittest.TestCase):
+
+    def test_toptail(self):
+        mask = np.asarray([np.nan, np.nan, 3, 4, 5, np.nan])
+        a = np.asarray([1, 2, 3, 4, 5, 6])
+        b = np.asarray([6, 5, 4, 3, 2, 1])
+        c = np.asarray([1, 2, 3, 4, 5, 6])
+        d = np.asarray([6, 5, 4, 3, 2, 1])
+        A, B, C, D = top_and_tail(a, b, c, d)
+        for arr in (A, B, C, D):
+            for item in arr:
+                self.assertFalse(np.isnan(item))
 
     def test_nextpow2(self):
         num = 888

--- a/bruges/util/util.py
+++ b/bruges/util/util.py
@@ -114,26 +114,19 @@ def next_pow2(num):
     return int(2**np.ceil(np.log2(num)))
 
 
-def top_and_tail(a, b=np.array([]), c=np.array([])):
+def top_and_tail(*arrays):
     """
-    Top and tail up to 3 arrays to the non-NaN extent of the first array.
+    Top and tail all arrays to the non-NaN extent of the first array.
 
     E.g. crop the NaNs from the top and tail of a well log.
 
-    TODO:
-        Make this work for an arbitrary number of arrays.
-
     """
-    nans = np.where(~np.isnan(a))[0]
+    nans = np.where(~np.isnan(arrays[0]))[0]
     first, last = nans[0], nans[-1]
-    a = a[first:last]
-    if b.any():
-        b = b[first:last]
-        if c.any():
-            c = c[first:last]
-            return a, b, c
-        return a, b
-    return a
+    ret_arrays = []
+    for array in arrays:
+        ret_arrays.append(array[first:last])
+    return ret_arrays
 
 
 def extrapolate(a):

--- a/bruges/util/util.py
+++ b/bruges/util/util.py
@@ -121,6 +121,9 @@ def top_and_tail(*arrays):
     E.g. crop the NaNs from the top and tail of a well log.
 
     """
+    if len(arrays) > 1:
+        for arr in arrays[1:]:
+            assert len(arr) == len(arrays[0])
     nans = np.where(~np.isnan(arrays[0]))[0]
     first, last = nans[0], nans[-1]
     ret_arrays = []

--- a/bruges/util/util.py
+++ b/bruges/util/util.py
@@ -125,7 +125,7 @@ def top_and_tail(*arrays):
     first, last = nans[0], nans[-1]
     ret_arrays = []
     for array in arrays:
-        ret_arrays.append(array[first:last])
+        ret_arrays.append(array[first:last+1])
     return ret_arrays
 
 


### PR DESCRIPTION
At the moment ``bruges.util.top_and_tail`` is limited to three arrays as arguments. This PR:

1. Allows any number of arrays as arguments
2. Fixes an existing bug where the last non-NaN is omitted. See forthcoming comment for an example.
3. Adds a rudimentary test.